### PR TITLE
add a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Ignore all .o files created when LittlevGL is built
+littlevLegatoComponent/littlevgl/*.o
+
+# Ignore the shared library created by the build
+littlevLegatoComponent/littlevgl/liblv.so
+
+# Ignore config files copied by the user
+littlevLegatoComponent/littlevgl/lv_conf.h
+littlevLegatoComponent/littlevgl/lv_drv_conf.h


### PR DESCRIPTION
Add a .gitignore to ignore build output and conf files created by the
user. This tidies up the output of "git status" commands.