### PR TITLE
increment tick the correct amount in handler

### DIFF
--- a/waveshareEinkDisplay/waveshareEinkDisplay.c
+++ b/waveshareEinkDisplay/waveshareEinkDisplay.c
@@ -10,7 +10,7 @@ static void displayTimer
 	le_timer_Ref_t displayTimerRef
 )
 {
-	lv_tick_inc(5);
+	lv_tick_inc(DISPLAY_SAMPLE_INTERVAL_IN_MILLISECONDS);
 	lv_task_handler();
 }
 


### PR DESCRIPTION
Fix a bug where the Legato timer handler was firing every 100 ms, but
LittlevGL was being told that time had advanced only 5 ms.