### PR TITLE
cleanup README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,24 @@
-# Integrate littlevgl into legato app
-This project demo how to integrate littlevlgl into legato app
+# Integrate LittlevGL into Legato app
 
-## Project Setup
-1. Clone lvgl library and create project:
-    * lvgl: https://github.com/littlevgl/lvgl
-    * lvgl drivers: https://github.com/littlevgl/lv_drivers
-    * Copy `lvgl/lv_conf_templ.h` change the name to `lv_conf.h` and place next to the lvgl folder  
-    * Copy `lv_drivers/lv_drv_conf_templ.h` change the name to `lv_drv_conf.h` and place next to the lvgl folder
-    
-We have app tree as bellow:
+This project demonstrates how to integrate LittlevlGL into a Legato app. The necessary LittlevGL
+dependencies are referenced by this repository as git submodules.
 
-   <img src="https://user-images.githubusercontent.com/17214533/53871383-b9b79400-402e-11e9-9690-898d3abe6bf2.png" width="350" alt="accessibility text">       
-
-2. Update configure file `lv_conf.h` for monochome display:
-   * Enable config content by set:
+## Setup
+1. Clone this repository with the `--recursive` option so that the submodules are retrieved as well.
+1. `cp littlevLegatoComponent/littlevgl/lvgl/lv_conf_templ.h littlevLegatoComponent/littlevgl/lv_conf.h`
+1. `cp littlevLegatoComponent/littlevgl/lv_drivers/lv_drv_conf_templ.h littlevLegatoComponent/littlevgl/lv_drv_conf.h`
+1. Make the following changes to `littlevLegatoComponent/littlevgl/lv_conf.h`:
+   1. At the top of the file, change the `#if 0` to `#if 1` to enable the file
+   1. Update logical dimension of screen for waveshare eink 2.13 Inch:
       ```c
-      #if 1 /*Set it to "1" to enable the content*/
-
-   * Update logical dimension of screen for waveshare eink 2.13 Inch: 
-       ```c
-       #define LV_HOR_RES          (128)
-       #define LV_VER_RES          (250)
-       
-   * Update default font type to use monochome font: 
+      #define LV_HOR_RES          (128)
+      #define LV_VER_RES          (250)
+      ```
+   1. Update default font type to use monochome font:
       ```c
       #define LV_FONT_DEFAULT        &lv_font_monospace_8
-      
-   * Enable font size 8 for monochome display and disable unsupported font: 
+      ```
+   1. Enable font size 8 for monochome display and disable unsupported font:
       ```c
       #define USE_LV_FONT_DEJAVU_10              0
       #define USE_LV_FONT_DEJAVU_10_LATIN_SUP    0
@@ -49,15 +41,14 @@ We have app tree as bellow:
       #define USE_LV_FONT_SYMBOL_40              0
 
       #define USE_LV_FONT_MONOSPACE_8            1
-     
-   * Update Color Depth is 1: 
+      ```
+   1. Update Color Depth to be 1:
       ```c
       #define LV_COLOR_DEPTH     1                     /*Color depth: 1/8/16/32*/
-     
-3. Update configure file `lv_drv_conf.h` for framebuffer:
-    * Enable config content by set:
-      ```c
-      #if 1 /*Set it to "1" to enable the content*/
-    * Update USE_FBDEV is 1 for using framebuffer device
+      ```
+1. Make the following changes to `littlevLegatoComponent/littlevgl/lv_drv_conf.h`:
+   1. At the top of the file, change the `#if 0` to `#if 1` to enable the file
+   1. Update USE_FBDEV to 1 for using framebuffer device
       ```c
       #define USE_FBDEV         1
+      ```


### PR DESCRIPTION
Clarified the instructions so that the image was no longer necessary.
Also switch to ordered list notation for the list of modifications.